### PR TITLE
Payment page dynamic form url

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,33 +9,31 @@ Dashboard is the BFF server and frontend to interact with all PaySuper related f
 REST API ([Management API](https://github.com/paysuper/paysuper-management-api)) as backend. 
 
 # PayOne web interface
-Uses Nuxt.js
 
 ## Usage
 ### Development
 
-1. Add a `.env.local` file:
-```
-VUE_APP_BACKEND_DOMAIN=http://localhost:8080
-PUBLIC_HOST=http://localhost:8080
-POST_MESSAGE_TARGET_ORIGIN=http://localhost:3030
-```
-
-2. Run these in different terminal windows:
-```
-npm run serve
-```
-```
-npm run serve:be
-```
-
-3. Also there are extra env-variables required for image uploading. Ask Andrey Solodovnikov for its values
+1. To use image uploading create a `.env.local` file with following variables. Ask Andrey Solodovnikov for the values
 ```
 S3_ACCESS_KEY_ID
 S3_SECRET_ACCESS_KEY
 S3_BUCKET_NAME
 S3_REGION
 ```
+
+2. Install dependecines:
+```
+yarn
+```
+
+2. Run these in different terminal windows:
+```
+yarn serve
+```
+```
+yarn serve:be
+```
+
 
 # Authentication backend for PayOne
 

--- a/backend/app/middleware/order-page.js
+++ b/backend/app/middleware/order-page.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const qs = require('qs');
 const Handlebars = require('handlebars');
+const { getEnvVariable } = require('../utils/env');
 
 const orderTemplate = fs.readFileSync(path.resolve('backend/templates/order-page.hbs'), 'utf-8');
 const template = Handlebars.compile(orderTemplate);
@@ -17,5 +18,9 @@ module.exports = function orderPage(ctx) {
       type: 'simple',
     }),
     formOptions: JSON.stringify((query.loading ? { layout: 'loading' } : {})),
+    sdkUrl: getEnvVariable(
+      'PAYSUPER_PAYMENT_FORM_URL',
+      'https://static.protocol.one/paysuper/form/dev/paysuper-form.js',
+    ),
   });
 };

--- a/backend/app/middleware/order-page.js
+++ b/backend/app/middleware/order-page.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const qs = require('qs');
 const Handlebars = require('handlebars');
-const { getEnvVariable } = require('../utils/env');
+const config = require('../../config/config');
 
 const orderTemplate = fs.readFileSync(path.resolve('backend/templates/order-page.hbs'), 'utf-8');
 const template = Handlebars.compile(orderTemplate);
@@ -18,9 +18,6 @@ module.exports = function orderPage(ctx) {
       type: 'simple',
     }),
     formOptions: JSON.stringify((query.loading ? { layout: 'loading' } : {})),
-    sdkUrl: getEnvVariable(
-      'PAYSUPER_PAYMENT_FORM_URL',
-      'https://static.protocol.one/paysuper/form/dev/paysuper-form.js',
-    ),
+    sdkUrl: config.paysuperSdkUrl,
   });
 };

--- a/backend/app/middleware/s3-upload.js
+++ b/backend/app/middleware/s3-upload.js
@@ -2,15 +2,7 @@ const aws = require('aws-sdk');
 const fs = require('fs');
 const _ = require('lodash');
 const uuid = require('uuid');
-const envUtils = require('../utils/env');
-
-const { getEnvVariable } = envUtils;
-const config = {
-  s3AccessKeyId: getEnvVariable('S3_ACCESS_KEY_ID'),
-  s3SecretAccessKey: getEnvVariable('S3_SECRET_ACCESS_KEY'),
-  s3BucketName: getEnvVariable('S3_BUCKET_NAME'),
-  s3Region: getEnvVariable('S3_REGION'),
-};
+const config = require('../../config/config');
 
 const allowedTypes = [
   {

--- a/backend/config/config.js
+++ b/backend/config/config.js
@@ -32,6 +32,16 @@ const config = {
   auth1SessionNamespace: 'auth1',
 
   corsValidOrigins: getEnvVariableArray('CORS_VALID_ORIGINS', 'http://localhost:3030'),
+
+  s3AccessKeyId: getEnvVariable('S3_ACCESS_KEY_ID'),
+  s3SecretAccessKey: getEnvVariable('S3_SECRET_ACCESS_KEY'),
+  s3BucketName: getEnvVariable('S3_BUCKET_NAME'),
+  s3Region: getEnvVariable('S3_REGION'),
+
+  paysuperSdkUrl: getEnvVariable(
+    'PAYSUPER_PAYMENT_FORM_URL',
+    'https://static.protocol.one/paysuper/form/dev/paysuper-form.js',
+  ),
 };
 
 module.exports = config;

--- a/backend/config/config.js
+++ b/backend/config/config.js
@@ -20,9 +20,9 @@ const config = {
 
   sentryDsn: getEnvVariable('SENTRY_DSN', 'https://2fc1a112904e472da22284cad12c6d87@sentry.tst.protocol.one/10'),
 
-  publicHost: getEnvVariable('PUBLIC_HOST', 'https://paysupermgmt.tst.protocol.one'),
+  publicHost: getEnvVariable('PUBLIC_HOST', 'http://localhost:8080'),
 
-  postMessageTargetOrigin: getEnvVariable('POST_MESSAGE_TARGET_ORIGIN', 'https://paysupermgmt.tst.protocol.one'),
+  postMessageTargetOrigin: getEnvVariable('POST_MESSAGE_TARGET_ORIGIN', 'http://localhost:3030'),
 
   auth1ClientId: getEnvVariable('AUTH1_CLIENT_ID', '5c77953f51c0950001436152'),
   auth1ClientSecret: getEnvVariable('AUTH1_CLIENT_SECRET', 'tGtL8HcRDY5X7VxEhyIye2EhiN9YyTJ5Ny0AndLNXQFgKCSgUKE0Ti4X9fHK6Qib'),

--- a/backend/config/webappConfigScheme.js
+++ b/backend/config/webappConfigScheme.js
@@ -1,7 +1,7 @@
 module.exports = {
   ownBackendUrl: {
     name: 'VUE_APP_BACKEND_DOMAIN',
-    default: '',
+    default: 'http://localhost:8080',
   },
   apiUrl: {
     name: 'VUE_APP_P1PAYAPI_URL',
@@ -10,5 +10,9 @@ module.exports = {
   websocketUrl: {
     name: 'VUE_APP_WEBSOCKET_URL',
     default: 'wss://cf.tst.protocol.one/connection/websocket',
+  },
+  paysuperJsSdkUrl: {
+    name: 'PAYSUPER_JS_SDK_URL',
+    default: 'https://static.protocol.one/paysuper/sdk/dev/paysuper.js',
   },
 };

--- a/backend/templates/order-page.hbs
+++ b/backend/templates/order-page.hbs
@@ -32,6 +32,6 @@
       window.PAYSUPER_ORDER_PARAMS = {{{ orderParams }}}
       window.PAYSUPER_FORM_OPTIONS = {{{ formOptions }}}
     </script>
-    <script src="https://static.protocol.one/paysuper/form/dev/paysuper-form.js"></script>
+    <script src="{{ sdkUrl }}"></script>
   </body>
 </html>

--- a/src/pages/PaymentFormSdk.vue
+++ b/src/pages/PaymentFormSdk.vue
@@ -2,6 +2,7 @@
 import axios from 'axios';
 import { trim } from 'lodash-es';
 import { mapState } from 'vuex';
+import assert from 'simple-assert';
 
 export default {
   name: 'PaymentFormSdk',
@@ -34,7 +35,8 @@ export default {
     },
   },
   async created() {
-    const { data } = await axios.get('https://static.protocol.one/paysuper/sdk/dev/paysuper.js');
+    assert(this.config.paysuperJsSdkUrl, 'paysuperJsSdkUrl is not defined');
+    const { data } = await axios.get(this.config.paysuperJsSdkUrl);
     const script = document.createElement('script');
     script.innerHTML = data;
     document.head.appendChild(script);


### PR DESCRIPTION
Форма и sdk имеют 2 типа сборки:
Тестовая: https://static.protocol.one/paysuper/sdk/dev/paysuper.js
Боевая: https://cdn.pay.super.com/paysdk/latest/paysuper.js

При этом и форма и sdk зависят от dashboard (там лежит страница с формой), который тоже бывает боевой и тестовый.
В общем, нужно чтобы все урлы соответствовали типу сборки
Если открываем демо-шоп на тесте, нужно, чтобы там тянулась тестовая sdk, она открывала тестовую страницу с формой и т.д.
Этот PR завершает круг соответствий.

Инженеры уже забили переменные:
Для tst
```
PAYSUPER_JS_SDK_URL=https://static.protocol.one/paysuper/sdk/dev/paysuper.js
PAYSUPER_PAYMENT_FORM_URL=https://static.protocol.one/paysuper/form/dev/paysuper-form.js
```

Для боя
```
PAYSUPER_JS_SDK_URL=https://cdn.pay.super.com/paysdk/latest/paysuper.js
PAYSUPER_PAYMENT_FORM_URL=https://cdn.pay.super.com/payform/latest/paysuper-form.js
```